### PR TITLE
SystemUI: adjust translation(Simplified Chinese)

### DIFF
--- a/SystemUI/res/values-zh-rCN/custom_strings.xml
+++ b/SystemUI/res/values-zh-rCN/custom_strings.xml
@@ -68,13 +68,13 @@
     <string name="quick_settings_aod_on_charge_label">充电时始终显示</string>
     <string name="quick_settings_aod_off_label">已关闭始终显示</string>
     <!-- Indication on the keyguard that is shown when the device is charging with a dash charger. Should match keyguard_plugged_in_dash_charging [CHAR LIMIT=40]-->
-    <string name="keyguard_indication_dash_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • Dash 闪充中 (还需 <xliff:g id="charging_time_left">%1$s</xliff:g>充满)</string>
-    <string name="keyguard_plugged_in_dash_charging"><xliff:g id="percentage">%s</xliff:g> • Dash 闪充</string>
+    <string name="keyguard_indication_dash_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • Dash 闪充中 • 将于<xliff:g id="charging_time_left">%1$s</xliff:g>后充满</string>
+    <string name="keyguard_plugged_in_dash_charging"><xliff:g id="percentage">%s</xliff:g> • Dash 闪充中</string>
     <!-- Indication on the keyguard that is shown when the device is charging with a warp charger. Should match keyguard_plugged_in_warp_charging [CHAR LIMIT=40]-->
-    <string name="keyguard_indication_warp_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • Warp 闪充中 (<xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g> 后充满)</string>
-    <string name="keyguard_plugged_in_warp_charging"><xliff:g id="percentage">%s</xliff:g> • Warp 闪充</string>
+    <string name="keyguard_indication_warp_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • Warp 闪充中 • 将于<xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g>后充满</string>
+    <string name="keyguard_plugged_in_warp_charging"><xliff:g id="percentage">%s</xliff:g> • Warp 闪充中</string>
     <!-- Indication on the keyguard that is shown when the device is charging with a VOOC charger. Should match keyguard_plugged_in_vooc_charging [CHAR LIMIT=40]-->
-    <string name="keyguard_indication_vooc_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • VOOC 闪充中 (还需 <xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g> 充满)</string>
+    <string name="keyguard_indication_vooc_charging_time" formatted="false"><xliff:g id="percentage">%2$s</xliff:g> • VOOC 闪充中 • 将于<xliff:g id="charging_time_left" example="4 hours and 2 minutes">%1$s</xliff:g>后充满</string>
     <string name="keyguard_plugged_in_vooc_charging"><xliff:g id="percentage">%s</xliff:g> • VOOC 闪充中</string>
     <!-- Advance location quick setting tile -->
     <string name="quick_settings_secondary_location_off"></string>


### PR DESCRIPTION
稍微调整下统一的翻译，但是由于本机型上没有显示正确的快充模式，不知是9R/8T机
型 维护作者没有开启还是其它原因，无法对照调中英文排版调整。还请ROM相关开发者帮忙检查